### PR TITLE
Adding text-to-speech function

### DIFF
--- a/text_to_speech.py
+++ b/text_to_speech.py
@@ -32,11 +32,13 @@ def tts_options(text: str, rate: int, voice: int, volume: float) -> int:
         engine.say(text)
         engine.runAndWait()
         return 0
-    except ImportError:
+    except ImportError as e:
         print("Requested driver not found")
+        print(e)
         return 1
-    except RuntimeError:
+    except RuntimeError as e:
         print("Driver failed to initialize")
+        print(e)
         return 1
 
 

--- a/text_to_speech.py
+++ b/text_to_speech.py
@@ -1,0 +1,57 @@
+import pyttsx3
+
+
+def tts_options(text: str, rate: int, voice: int, volume: float) -> int:
+    '''
+    TTS function that converts the provided text to speech and plays the audio,
+    based on provided speech rate, voice sound, and volume
+
+    :param text: String to be spoken 
+    :param rate: Integer speech rate in words per minute, must be greater than 0
+    :param voice: Integer determining selected voice from list, from 0 to 47 inclusive
+    :param volume: Float determining volume of audio, from 0.0 to 1.0 inclusive
+    :return: 0 on success, 1 on failure
+    '''
+
+    if rate <= 0:
+        print("Rate must be greater than 0")
+        return 1
+    if voice < 0 or voice > 47:
+        print("Voice not in range [0, 47]")
+        return 1
+    if volume < 0.0 or volume > 1.0:
+        print("Volume not in range [0.0, 1.0]")
+        return 1
+
+    try:
+        engine = pyttsx3.init()
+        voices = list(engine.getProperty("voices"))
+        engine.setProperty("voice", voices[voice].id)
+        engine.setProperty("rate", rate)
+        engine.setProperty("volume", volume)
+        engine.say(text)
+        engine.runAndWait()
+        return 0
+    except ImportError:
+        print("Requested driver not found")
+        return 1
+    except RuntimeError:
+        print("Driver failed to initialize")
+        return 1
+
+
+def tts_default(text: str) -> None:
+    '''
+    TTS function that converts the provided text to speech and plays the audio,
+    based on default speech options:
+
+    rate: 200 wpm
+    voice: 0 (male)
+    volume: 1.0 (full)
+
+    :param text: String to be spoken
+    :return: None
+    '''
+
+    pyttsx3.speak(text)
+


### PR DESCRIPTION
## Summary
Added a file `text_to_speech.py` that makes use of the offline python library pyttsx3 to implement text to speech functionality.

Fixes #1 

## Details
There are two functions in the file, `tts_options()` and `tts_default()`.

Both of them take in a string input, and play the equivalent audio within the function. However, while `tts_default()` simply generates the audio using the default settings (which are described in the function), `tts_options()` allows the user to select the speech rate, type of voice, and volume as well.

## Testing
All of the additional arguments in `tts_options()` are argument checked, and all known errors raised by the library functions themselves are handled.

I tested these functions by simply feeding them different strings and making sure I got the appropriate audio output. 

## Issues To Consider
While I never had a problem with the audio itself, I noticed that with both library functions used to produce the audio (`runAndWait()` and `speak()`) there is a delay of about 1-2 seconds between the audio finishing playing and the function returning. 

However, this is not always the case. The longer the input string is, the shorter the delay, and with a long enough string there is no delay at all.

I was not able to figure out why this occurs and am curious if others could help shed some light on it.