### PR TITLE
Add log_queries.py to log question/answer pairs to a Google Sheet

### DIFF
--- a/log_queries.py
+++ b/log_queries.py
@@ -1,0 +1,72 @@
+import datetime
+
+import pickle
+import os.path
+
+from googleapiclient.discovery import build
+from google_auth_oauthlib.flow import InstalledAppFlow
+from google.auth.transport.requests import Request
+
+# If modifying these scopes, delete the file token.pickle.
+SCOPES = ['https://www.googleapis.com/auth/spreadsheets']  # Allows read and write access
+
+# The ID, range, and auth path for appending to the spreadsheet.
+SPREADSHEET_ID = '15f_zVJxNnUz_9G5ZYPery68rR8PyUnO0yWKSyGQjy4w'
+RANGE_NAME = 'A1'  # Should always place the new query correctly at the bottom of the table
+AUTH_PATH = 'credentials.json'
+
+
+def config_api():
+    """
+    Configures the Google Sheets API service to be used for appending data
+
+    :return: The service as a Resource object
+    """
+
+    creds = None
+
+    # The file token.pickle stores the user's access and refresh tokens, and is
+    # created automatically when the authorization flow completes for the first
+    # time.
+    if os.path.exists('token.pickle'):
+        with open('token.pickle', 'rb') as token:
+            creds = pickle.load(token)
+
+    # If there are no (valid) credentials available, let the user log in.
+    if not creds or not creds.valid:
+        if creds and creds.expired and creds.refresh_token:
+            creds.refresh(Request())
+        else:
+            flow = InstalledAppFlow.from_client_secrets_file(
+                AUTH_PATH, SCOPES)
+            creds = flow.run_local_server(port=0)
+
+        # Save the credentials for the next run
+        with open('token.pickle', 'wb') as token:
+            pickle.dump(creds, token)
+
+    return build('sheets', 'v4', credentials=creds)
+
+
+def log_query(service, question: str, answer: str) -> None:
+    """
+    Logs a user query and chat bot response to a Google Sheet as well as the timestamp
+
+    :param service: Google Sheets API service
+    :param question: User question
+    :param answer: Chat bot answer
+    :return: None
+    """
+
+    timestamp = str(datetime.datetime.now())
+    values = [[question, answer, timestamp]]
+    body = {
+        'values': values
+    }
+
+    service.spreadsheets().values().append(
+        spreadsheetId=SPREADSHEET_ID,
+        range=RANGE_NAME,
+        valueInputOption='RAW',
+        body=body
+    ).execute()

--- a/log_queries.py
+++ b/log_queries.py
@@ -20,7 +20,7 @@ def config_api():
     """
     Configures the Google Sheets API service to be used for appending data
 
-    :return: The service as a Resource object
+    :return: The service as a Resource object, or None if there is no pickle and the authentication JSON can't be found
     """
 
     creds = None
@@ -37,8 +37,11 @@ def config_api():
         if creds and creds.expired and creds.refresh_token:
             creds.refresh(Request())
         else:
-            flow = InstalledAppFlow.from_client_secrets_file(
-                AUTH_PATH, SCOPES)
+            try:
+                flow = InstalledAppFlow.from_client_secrets_file(AUTH_PATH, SCOPES)
+            except FileNotFoundError as e:
+                print(e)
+                return None
             creds = flow.run_local_server(port=0)
 
         # Save the credentials for the next run
@@ -64,9 +67,12 @@ def log_query(service, question: str, answer: str) -> None:
         'values': values
     }
 
-    service.spreadsheets().values().append(
-        spreadsheetId=SPREADSHEET_ID,
-        range=RANGE_NAME,
-        valueInputOption='RAW',
-        body=body
-    ).execute()
+    try:
+        service.spreadsheets().values().append(
+            spreadsheetId=SPREADSHEET_ID,
+            range=RANGE_NAME,
+            valueInputOption='RAW',
+            body=body
+        ).execute()
+    except Exception as e:
+        print(e)

--- a/log_queries.py
+++ b/log_queries.py
@@ -11,7 +11,7 @@ from google.auth.transport.requests import Request
 SCOPES = ['https://www.googleapis.com/auth/spreadsheets']  # Allows read and write access
 
 # The ID, range, and auth path for appending to the spreadsheet.
-SPREADSHEET_ID = '15f_zVJxNnUz_9G5ZYPery68rR8PyUnO0yWKSyGQjy4w'
+SPREADSHEET_ID = ''
 RANGE_NAME = 'A1'  # Should always place the new query correctly at the bottom of the table
 AUTH_PATH = 'credentials.json'
 
@@ -51,28 +51,33 @@ def config_api():
     return build('sheets', 'v4', credentials=creds)
 
 
-def log_query(service, question: str, answer: str) -> None:
+def log_query(service, question: str, answer: str, sentiment: str = "N/A", spreadsheet_id: str = SPREADSHEET_ID) -> int:
     """
     Logs a user query and chat bot response to a Google Sheet as well as the timestamp
 
     :param service: Google Sheets API service
     :param question: User question
     :param answer: Chat bot answer
-    :return: None
+    :param sentiment: Positive or negative sentiment associated with the question/answer, currently defaults to "N/A"
+    :param spreadsheet_id: ID of the spreadsheet to append to, currently defaults to an empty string
+    :return: 0 on success, 1 on failure
     """
 
     timestamp = str(datetime.datetime.now())
-    values = [[question, answer, timestamp]]
+    values = [[question, answer, sentiment, timestamp]]
     body = {
         'values': values
     }
 
     try:
         service.spreadsheets().values().append(
-            spreadsheetId=SPREADSHEET_ID,
+            spreadsheetId=spreadsheet_id,
             range=RANGE_NAME,
             valueInputOption='RAW',
             body=body
         ).execute()
     except Exception as e:
         print(e)
+        return 1
+
+    return 0


### PR DESCRIPTION
## Summary

Added a new file `log_queries.py` that uses the Google Sheets API to log a user question and the chat bot answer to a table, along with the timestamp.

Fixes #35 

## Details

`log_queries.py` contains two functions, `config_api()` and `log_query()`.

`config_api()` takes no arguments and returns the activated API service for use. It currently requires the authentication JSON to be in the same directory as `log_queries.py`, but the JSON path name can be changed.

`log_query()` takes as arguments the Google Sheets API service generated by `config_api()`, the user question as a string, and the chat bot response as a string. It logs the question and response to the Google Sheet specified by `SPREADSHEET_ID`, generating a timestamp using the `datetime` package.

## Testing

I've tested the logging function several times with various questions and answers, and I've confirmed that both functions respond appropriately when faced with errors, namely:
- Scope is in readonly mode
- Incorrect spreadsheet ID
- Can't find authentication JSON when there is no pickle

## Issues to Consider

In `log_query()`, there were several exceptions raised when creating and executing an append request that were native to one of the packages, and I wasn't sure how best to catch them all so I just caught `Exception`, which I know is not encouraged.

Additionally, Chidi, I wasn't sure exactly how you wanted me to handle the relationship between `api_config()` and `log_query()` so I just had `api_config()` return the service, which could then be passed to `log_query()` to use. If you had a slightly different vision in mind, feel free to change it.